### PR TITLE
ci: Use Node 24 in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.12.0
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
# Ticket(s) Closed

Apparently Node 22 does not support the OIDC flow used here by the publishing workflow, so I'm upgrading to see if that fixes things.

## What

## Why

## How

## Tests
