### PR TITLE
fix: add NPM_TOKEN auth and --provenance to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish --access public
+          npm publish --access public --provenance
           echo "✅ Published ${PACKAGE_NAME} ${VERSION} to npm"
 
       - name: Summary


### PR DESCRIPTION
## Problem

The **Publish to npm** step in `.github/workflows/release.yml` runs
`npm publish --access public` but provides **no auth token**, so every
release attempt hard-fails with an authentication error.

`actions/setup-node` (line ~90) is configured with
`registry-url: https://registry.npmjs.org`, which writes an
auth-aware `.npmrc` — but npm only populates the token field when
`NODE_AUTH_TOKEN` is present in the **step's** `env` block. That env
block was missing entirely.

## Fix

Two changes to the **Publish to npm** step:

1. **`env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`** — wires the
   token into the `.npmrc` that setup-node already prepared.

2. **`--provenance`** added to the publish command — the job already
   grants `id-token: write` for OIDC, and Node 24 ships with npm 10.x
   (provenance requires npm ≥9.5), so OIDC attestation is available at
   no extra cost.

## Secret name assumption

`NPM_TOKEN` follows the org-wide `<REGISTRY>_TOKEN` convention seen in
sibling repos (`PYPI_TOKEN` in django-paradedb, `RUBYGEMS_TOKEN` in
rails-paradedb). Please confirm a secret named **`NPM_TOKEN`** exists
in the repo or org settings before merging — if the actual secret has a
different name, update line 126 accordingly.

## Test plan

- [ ] Confirm `NPM_TOKEN` secret exists in repo/org settings
- [ ] Trigger a dry-run or beta release and verify the publish step
      authenticates and completes without error
- [ ] Verify provenance attestation appears on the npm package page