### PR TITLE
ci: run Prettier from repo's pinned version; sync Prettier 3.9.4 + pnpm 11.10.0

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -45,8 +45,6 @@ jobs:
         run: npm install -g markdownlint-cli
 
       - name: Run Markdown Lint
-        # Ignore node_modules — pnpm now populates it, and markdownlint (unlike
-        # Prettier) does not skip it by default.
         run: markdownlint "**/*.md" --ignore node_modules
 
       - name: Run Prettier

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -30,14 +30,24 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6
+        with:
+          cache: pnpm
 
-      - name: Install Prettier and markdownlint
-        run: npm install -g prettier markdownlint-cli
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
 
       - name: Run Markdown Lint
-        run: markdownlint "**/*.md"
+        # Ignore node_modules — pnpm now populates it, and markdownlint (unlike
+        # Prettier) does not skip it by default.
+        run: markdownlint "**/*.md" --ignore node_modules
 
       - name: Run Prettier
-        run: prettier --check "{**/*.md,**/*.mdx}" --ignore-path .prettierignore
+        run: pnpm exec prettier --check "{**/*.md,**/*.mdx}" --ignore-path .prettierignore

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -27,11 +27,16 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6
+        with:
+          cache: pnpm
 
-      - name: Install Prettier
-        run: npm install -g prettier
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check YAML Formatting
-        run: prettier --check "**/*.{yml,yaml}"
+        run: pnpm exec prettier --check "**/*.{yml,yaml}"

--- a/package.json
+++ b/package.json
@@ -2,35 +2,6 @@
   "name": "@paradedb/drizzle-paradedb",
   "version": "0.1.0",
   "description": "The official Drizzle integration for ParadeDB",
-  "type": "module",
-  "homepage": "https://github.com/paradedb/drizzle-paradedb",
-  "bugs": {
-    "url": "https://github.com/paradedb/drizzle-paradedb/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/paradedb/drizzle-paradedb.git"
-  },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
-    "db:setup": "bash scripts/setup_db.sh",
-    "examples": "bash scripts/run_examples.sh",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "test": "vitest run",
-    "typecheck": "tsc --noEmit"
-  },
   "keywords": [
     "paradedb",
     "drizzle",
@@ -42,24 +13,53 @@
     "full text search",
     "hybrid search"
   ],
-  "author": "ParadeDB, Inc.",
-  "license": "MIT",
-  "engines": {
-    "node": ">=22.12.0"
+  "homepage": "https://github.com/paradedb/drizzle-paradedb",
+  "bugs": {
+    "url": "https://github.com/paradedb/drizzle-paradedb/issues"
   },
-  "packageManager": "pnpm@10.33.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/paradedb/drizzle-paradedb.git"
+  },
+  "license": "MIT",
+  "author": "ParadeDB, Inc.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "db:setup": "bash scripts/setup_db.sh",
+    "examples": "bash scripts/run_examples.sh",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "drizzle-orm": "1.0.0-rc.2"
+  },
   "devDependencies": {
     "@types/node": "^26.0.1",
     "@vitest/coverage-v8": "^4.1.6",
     "drizzle-kit": "1.0.0-rc.2",
     "postgres": "^3.4.9",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.4",
     "tsup": "^8.5.1",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
-  "dependencies": {
-    "drizzle-orm": "1.0.0-rc.2"
+  "packageManager": "pnpm@11.10.0",
+  "engines": {
+    "node": ">=22.12.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         specifier: ^3.4.9
         version: 3.4.9
       prettier:
-        specifier: ^3.8.3
+        specifier: ^3.9.4
         version: 3.9.4
       tsup:
         specifier: ^8.5.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 overrides:
   esbuild@>=0.17.0 <0.28.1: ">=0.28.1"
   vite@>=8.0.0 <8.0.16: ">=8.0.16"
+
+# pnpm 11 hard-fails (ERR_PNPM_IGNORED_BUILDS) on unapproved build scripts;
+# esbuild (used by tsup/vitest) needs to compile, so allow it explicitly.
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Make the lint CI use the repo's pinned Prettier instead of the latest release, and sync Prettier / pnpm to match `paradedb/website`.

## Why

`lint-markdown.yml` and `lint-yaml.yml` ran `npm install -g prettier`, which always pulls the **latest** release rather than the version this repo pins — the CI-vs-local drift that broke `paradedb/website` in paradedb/website#338. `ci.yml` already runs Prettier from the lockfile via `pnpm format:check`; this brings the two standalone lint jobs in line. See paradedb/paradedb#5477 for the org-wide rollout.

## How

**`lint-yaml.yml`, `lint-markdown.yml`**

- Add `pnpm/action-setup@v6` + `cache: pnpm`, install with `pnpm install --frozen-lockfile --ignore-scripts` (lint jobs don't need native builds).
- Run `pnpm exec prettier` instead of the global `prettier`.
- `markdownlint` now ignores `node_modules` (pnpm populates it; unlike Prettier, markdownlint doesn't skip it by default).

**`package.json` / `pnpm-lock.yaml`**

- `prettier` `^3.8.3` → `^3.9.4` (the lockfile already resolved `3.9.4`; makes the declared range honest).
- `packageManager` `pnpm@10.33.0` → `pnpm@11.10.0` to match `website`.
- Sort top-level fields to the conventional order (`sort-package-json`); no value changes.

**`pnpm-workspace.yaml`**

- Add `allowBuilds: { esbuild: true }`. pnpm 11 hard-fails (`ERR_PNPM_IGNORED_BUILDS`) on unapproved build scripts where pnpm 10 only warned, so `ci.yml`'s `pnpm install` needs esbuild (used by `tsup`/`vitest`) explicitly approved.

## Tests

- `prettier --check .` (mirrors `ci.yml`), plus the `yaml` and `md/mdx` globs, all pass on `3.9.4`.
- Fresh `pnpm install` on `11.10.0` exits `0` (no ignored-builds error); `pnpm build` (tsup/esbuild) succeeds.
- Full CI matrix (Node 22/23/24 × PG 15/18) and all lint jobs pass.
