### PR TITLE
ci: Consolidate permissions at workflow level

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,14 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   release:
     name: Build and Publish to npm
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
 
     steps:
       - name: Validate confirmation


### PR DESCRIPTION
Standardizes on a **single workflow-level `permissions:` block** per workflow, rather than a mix of workflow- and job-level declarations, so every workflow declares its scopes in one predictable place.

Where a job declared its own block, the workflow-level block is the union of what every job needs (job-level `permissions:` replaces workflow-level rather than merging with it, so the union is what preserves current behaviour).

No job loses a scope. In multi-job workflows some jobs gain one they don't use — noted per-repo in the commit message. Fork pull requests always receive a read-only `GITHUB_TOKEN` regardless of repository settings, so any widened scope is only reachable from branches by users who already have write access.

Part of the workflow-permissions hardening ahead of switching the org default workflow permissions to read-only.

https://claude.ai/code/session_01Rg3UBFSnmKMPQLNpNKkn8d
