### PR TITLE
feat: native vector search support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Added
+
+- Native vector search support: `vector` columns and `vectorField` opclasses in ParadeDB indexes, plus `l2Distance`/`cosineDistance`/`innerProduct` re-exports for Top-K queries ([paradedb/paradedb#5685](https://github.com/paradedb/paradedb/issues/5685)).
+
 ### Changed
 
 - **Breaking**: `bm25Index`, `bm25Field`, and `Bm25IndexOptions` are renamed to `paradedbIndex`, `paradedbField`, and `ParadedbIndexOptions`, and indexes are always created with `USING paradedb`, which requires pg_search 0.25.0+ ([paradedb/paradedb#5706](https://github.com/paradedb/paradedb/issues/5706)).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,58 @@ The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](htt
 | ParadeDB   | 0.25.0+                       |
 | PostgreSQL | 15+ (with ParadeDB extension) |
 
+## Vector Search
+
+ParadeDB can index [pgvector](https://github.com/pgvector/pgvector) `vector` columns directly inside a ParadeDB index. Declare the column with Drizzle's `vector` type (re-exported by this package), pick a distance metric for the index, and query with the matching distance operator:
+
+```ts
+import { pgTable, integer, text } from "drizzle-orm/pg-core";
+import { indexing, search } from "@paradedb/drizzle-paradedb";
+
+const items = pgTable(
+  "items",
+  {
+    id: integer("id").primaryKey(),
+    description: text("description").notNull(),
+    embedding: indexing.vector("embedding", { dimensions: 384 }),
+  },
+  (table) => [
+    indexing
+      .paradedbIndex("items_search_idx")
+      .on(
+        table.id,
+        table.description,
+        indexing.vectorField(table.embedding, "cosine"),
+      ),
+  ],
+);
+```
+
+This emits `CREATE INDEX ... USING paradedb ("id", "description", "embedding" vector_cosine_ops) WITH (key_field=id)`.
+
+Top-K nearest-neighbor queries need two things to be served by the index: a `@@@` predicate (use `search.all` to match every row) and a `LIMIT`:
+
+```ts
+const results = await db
+  .select({ id: items.id, description: items.description })
+  .from(items)
+  .where(search.all(items.id))
+  .orderBy(search.cosineDistance(items.embedding, queryEmbedding))
+  .limit(10);
+```
+
+Replace `search.all` with any other predicate (e.g. `search.matchAll`) to filter candidates before ranking by distance.
+
+The `ORDER BY` distance function must match the metric the index was built with, otherwise the query still returns correct results but falls back to a plain sort instead of Top-K index pushdown:
+
+| Metric (`vectorField`) | Operator class      | Distance function       | Operator |
+| ---------------------- | ------------------- | ----------------------- | -------- |
+| `"l2"` (default)       | `vector_l2_ops`     | `search.l2Distance`     | `<->`    |
+| `"cosine"`             | `vector_cosine_ops` | `search.cosineDistance` | `<=>`    |
+| `"ip"`                 | `vector_ip_ops`     | `search.innerProduct`   | `<#>`    |
+
+Vector fields in ParadeDB indexes require a pg_search version newer than 0.24; on older versions index creation fails and the [vector search example](examples/vector-search.ts) and tests skip themselves.
+
 ## Examples
 
 Run all examples:
@@ -66,6 +118,7 @@ pnpm examples autocomplete.ts
 - [Autocomplete](examples/autocomplete.ts)
 - [More Like This](examples/more-like-this.ts)
 - [Hybrid RRF](examples/hybrid-rrf.ts)
+- [Vector search](examples/vector-search.ts)
 - [RAG](examples/rag.ts)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -36,68 +36,17 @@
 
 # ParadeDB for Drizzle
 
-The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#drizzle) to begin.
+The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both full-text and [vector search](https://docs.paradedb.com/documentation/vector/overview): ParadeDB indexes can index [pgvector](https://github.com/pgvector/pgvector) `vector` columns for Top-K retrieval. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#drizzle) to begin.
 
 ## Requirements & Compatibility
 
-| Component  | Supported                     |
-| ---------- | ----------------------------- |
-| Node       | 22.12+                        |
-| Drizzle    | 1.0+                          |
-| ParadeDB   | 0.25.0+                       |
-| PostgreSQL | 15+ (with ParadeDB extension) |
-
-## Vector Search
-
-ParadeDB can index [pgvector](https://github.com/pgvector/pgvector) `vector` columns directly inside a ParadeDB index. Declare the column with Drizzle's `vector` type (re-exported by this package), pick a distance metric for the index, and query with the matching distance operator:
-
-```ts
-import { pgTable, integer, text } from "drizzle-orm/pg-core";
-import { indexing, search } from "@paradedb/drizzle-paradedb";
-
-const items = pgTable(
-  "items",
-  {
-    id: integer("id").primaryKey(),
-    description: text("description").notNull(),
-    embedding: indexing.vector("embedding", { dimensions: 384 }),
-  },
-  (table) => [
-    indexing
-      .paradedbIndex("items_search_idx")
-      .on(
-        table.id,
-        table.description,
-        indexing.vectorField(table.embedding, "cosine"),
-      ),
-  ],
-);
-```
-
-This emits `CREATE INDEX ... USING paradedb ("id", "description", "embedding" vector_cosine_ops) WITH (key_field=id)`.
-
-Top-K nearest-neighbor queries need two things to be served by the index: a `@@@` predicate (use `search.all` to match every row) and a `LIMIT`:
-
-```ts
-const results = await db
-  .select({ id: items.id, description: items.description })
-  .from(items)
-  .where(search.all(items.id))
-  .orderBy(search.cosineDistance(items.embedding, queryEmbedding))
-  .limit(10);
-```
-
-Replace `search.all` with any other predicate (e.g. `search.matchAll`) to filter candidates before ranking by distance.
-
-The `ORDER BY` distance function must match the metric the index was built with, otherwise the query still returns correct results but falls back to a plain sort instead of Top-K index pushdown:
-
-| Metric (`vectorField`) | Operator class      | Distance function       | Operator |
-| ---------------------- | ------------------- | ----------------------- | -------- |
-| `"l2"` (default)       | `vector_l2_ops`     | `search.l2Distance`     | `<->`    |
-| `"cosine"`             | `vector_cosine_ops` | `search.cosineDistance` | `<=>`    |
-| `"ip"`                 | `vector_ip_ops`     | `search.innerProduct`   | `<#>`    |
-
-Vector fields in ParadeDB indexes require a pg_search version newer than 0.24; on older versions index creation fails and the [vector search example](examples/vector-search.ts) and tests skip themselves.
+| Component  | Supported                                                         |
+| ---------- | ----------------------------------------------------------------- |
+| Node       | 22.12+                                                            |
+| Drizzle    | 1.0+                                                              |
+| ParadeDB   | 0.25.0+                                                           |
+| PostgreSQL | 15+ (with ParadeDB extension)                                     |
+| pgvector   | Required for vector search; included in the ParadeDB Docker image |
 
 ## Examples
 
@@ -115,11 +64,11 @@ pnpm examples autocomplete.ts
 
 - [Quickstart](examples/quickstart.ts)
 - [Faceted search](examples/faceted-search.ts)
+- [Vector search](examples/vector-search.ts)
+- [Hybrid RRF](examples/hybrid-rrf.ts)
+- [RAG](examples/rag.ts)
 - [Autocomplete](examples/autocomplete.ts)
 - [More Like This](examples/more-like-this.ts)
-- [Hybrid RRF](examples/hybrid-rrf.ts)
-- [Vector search](examples/vector-search.ts)
-- [RAG](examples/rag.ts)
 
 ## Contributing
 

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -30,6 +30,7 @@ export const mockItems = pgTable(
     inStock: boolean("in_stock").notNull(),
     createdAt: timestamp("created_at").notNull(),
     metadata: jsonb("metadata").$type<Record<string, unknown> | null>(),
+    embedding: indexing.vector("embedding", { dimensions: 8 }),
   },
   (table) => [
     indexing
@@ -42,6 +43,7 @@ export const mockItems = pgTable(
         table.inStock,
         table.createdAt,
         table.metadata,
+        indexing.vectorField(table.embedding, "cosine"),
       ),
   ],
 );
@@ -82,7 +84,7 @@ export async function setupMockItems(): Promise<void> {
   await db.execute(sql`DROP INDEX IF EXISTS search_idx`);
   await db.execute(sql`
     CREATE INDEX search_idx ON mock_items
-    USING paradedb (id, description, ((category)::pdb.literal), rating, in_stock, created_at, metadata, weight_range, last_updated_date, latest_available_time)
+    USING paradedb (id, description, ((category)::pdb.literal), rating, in_stock, created_at, metadata, weight_range, last_updated_date, latest_available_time, embedding vector_cosine_ops)
     WITH (key_field='id', json_fields='{"metadata":{"fast":true}}')
   `);
 }

--- a/examples/hybrid-rrf.ts
+++ b/examples/hybrid-rrf.ts
@@ -66,7 +66,10 @@ async function hybridSearch(
   rrfK = 60,
   limit = 5,
 ): Promise<HybridRow[]> {
-  const vectorDistance = search.cosineDistance(sql`embedding`, queryEmbedding);
+  const vectorDistance = search.cosineDistance(
+    mockItems.embedding,
+    queryEmbedding,
+  );
   const fulltext = db.$with("fulltext").as(
     db
       .select({

--- a/examples/hybrid-rrf.ts
+++ b/examples/hybrid-rrf.ts
@@ -66,7 +66,7 @@ async function hybridSearch(
   rrfK = 60,
   limit = 5,
 ): Promise<HybridRow[]> {
-  const vectorDistance = sql`embedding <=> ${JSON.stringify(queryEmbedding)}::vector`;
+  const vectorDistance = search.cosineDistance(sql`embedding`, queryEmbedding);
   const fulltext = db.$with("fulltext").as(
     db
       .select({

--- a/examples/rag.ts
+++ b/examples/rag.ts
@@ -1,17 +1,37 @@
-import { desc } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 
 import { closeDb, db, mockItems, setupMockItems } from "./common.js";
 import { search } from "../src/index.js";
 
 const model = process.env.RAG_MODEL ?? "anthropic/claude-3-haiku";
 
-type RetrievedItem = typeof mockItems.$inferSelect & { score: number };
+type RetrievedItem = Omit<typeof mockItems.$inferSelect, "embedding"> & {
+  distance: number;
+};
+
+// In production, compute query embeddings with the same model that produced
+// the stored embeddings. These fixed vectors stand in for that model.
+const questions: { question: string; embedding: number[] }[] = [
+  {
+    question: "What running shoes do you have?",
+    embedding: [-0.02, 0.47, -0.76, 0.13, 0.34, 0.04, 0.19, -0.19],
+  },
+  {
+    question: "I need comfortable shoes for everyday use",
+    embedding: [-0.04, 0.4, -0.66, -0.07, 0.43, 0.21, 0.39, -0.1],
+  },
+  {
+    question: "Do you have any wireless audio products?",
+    embedding: [-0.08, 0.19, -0.88, 0.16, 0.3, 0.03, -0.08, -0.23],
+  },
+];
 
 export async function runRag(): Promise<void> {
   console.log("=".repeat(60));
   console.log("RAG with drizzle-paradedb + OpenRouter");
   console.log("=".repeat(60));
   console.log(`Using model: ${model}`);
+  console.log("\nRetrieval: keyword filter + Top-K by vector distance.");
   if (!process.env.OPENROUTER_API_KEY) {
     console.log(
       "OPENROUTER_API_KEY is not set; generation responses will be skipped.",
@@ -20,15 +40,21 @@ export async function runRag(): Promise<void> {
 
   await setupMockItems();
 
-  await rag("What running shoes do you have?");
-  await rag("I need comfortable shoes for everyday use");
-  await rag("Do you have any wireless audio products?");
+  for (const { question, embedding } of questions) {
+    await rag(question, embedding);
+  }
 
   console.log("\n" + "=".repeat(60));
   console.log("Done!");
 }
 
-async function retrieve(query: string, topK = 5): Promise<RetrievedItem[]> {
+async function retrieve(
+  query: string,
+  queryEmbedding: number[],
+  topK = 5,
+): Promise<RetrievedItem[]> {
+  const distance = search.cosineDistance(mockItems.embedding, queryEmbedding);
+
   return db
     .select({
       id: mockItems.id,
@@ -38,11 +64,11 @@ async function retrieve(query: string, topK = 5): Promise<RetrievedItem[]> {
       inStock: mockItems.inStock,
       createdAt: mockItems.createdAt,
       metadata: mockItems.metadata,
-      score: search.score(mockItems.id),
+      distance: sql<number>`(${distance})::float8`,
     })
     .from(mockItems)
     .where(search.parse(mockItems.id, query, { lenient: true }))
-    .orderBy(desc(search.score(mockItems.id)))
+    .orderBy(distance)
     .limit(topK);
 }
 
@@ -100,15 +126,17 @@ Provide a helpful, concise answer. If the products don't match what the customer
   }
 }
 
-async function rag(query: string): Promise<void> {
+async function rag(query: string, queryEmbedding: number[]): Promise<void> {
   console.log("\n" + "=".repeat(60));
   console.log(`Question: ${query}`);
   console.log("=".repeat(60));
 
-  const items = await retrieve(query);
+  const items = await retrieve(query, queryEmbedding);
   console.log(`\nRetrieved ${items.length} products:`);
   for (const item of items) {
-    console.log(`  - ${item.description} (score: ${item.score.toFixed(2)})`);
+    console.log(
+      `  - ${item.description} (distance: ${item.distance.toFixed(4)})`,
+    );
   }
 
   console.log("\nAnswer:");

--- a/examples/vector-search.ts
+++ b/examples/vector-search.ts
@@ -1,0 +1,158 @@
+import { eq, sql } from "drizzle-orm";
+import { integer, pgTable, text } from "drizzle-orm/pg-core";
+import { readFile } from "node:fs/promises";
+
+import { closeDb, db } from "./common.js";
+import { indexing, search } from "../src/index.js";
+
+const vectorItems = pgTable(
+  "vector_search_items",
+  {
+    id: integer("id").primaryKey(),
+    description: text("description").notNull(),
+    embedding: indexing.vector("embedding", { dimensions: 384 }),
+  },
+  (table) => [
+    indexing
+      .paradedbIndex("vector_search_items_idx")
+      .on(
+        table.id,
+        table.description,
+        indexing.vectorField(table.embedding, "cosine"),
+      ),
+  ],
+);
+
+export async function runVectorSearch(): Promise<void> {
+  console.log("=".repeat(60));
+  console.log("Vector Search inside a ParadeDB Index");
+  console.log("=".repeat(60));
+  console.log("\nTop-K nearest neighbors served by the paradedb index.");
+  console.log("A @@@ predicate and a LIMIT are required for index pushdown.");
+
+  try {
+    await setupVectorItems();
+  } catch (error) {
+    console.log(
+      `\nSkipped: requires pg_search with vector support (${String(error)})`,
+    );
+    return;
+  }
+
+  await semanticSearch("Sturdy hiking boots");
+  await filteredSemanticSearch("Sturdy hiking boots", "shoes");
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Done!");
+}
+
+async function setupVectorItems(): Promise<void> {
+  await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+  await db.execute(sql`DROP TABLE IF EXISTS vector_search_items CASCADE`);
+  await db.execute(sql`
+    CREATE TABLE vector_search_items (
+      id integer PRIMARY KEY,
+      description text NOT NULL,
+      embedding vector(384)
+    )
+  `);
+
+  await db.insert(vectorItems).values(await loadItems());
+
+  await db.execute(sql`
+    CREATE INDEX vector_search_items_idx ON vector_search_items
+    USING paradedb (id, description, embedding vector_cosine_ops)
+    WITH (key_field='id')
+  `);
+  console.log("\n✓ Indexed vector_search_items with a cosine vector field");
+}
+
+async function loadItems(): Promise<
+  { id: number; description: string; embedding: number[] }[]
+> {
+  const csv = await readFile(
+    new URL("./hybrid_rrf/mock_items_embeddings.csv", import.meta.url),
+    "utf8",
+  );
+
+  return csv
+    .trim()
+    .split("\n")
+    .slice(1)
+    .map((line) => {
+      const match = line.match(/^(\d+),(.*),"(\[.*\])"$/);
+      if (!match) throw new Error(`Invalid embedding CSV row: ${line}`);
+      return {
+        id: Number(match[1]),
+        description: match[2],
+        embedding: JSON.parse(match[3]) as number[],
+      };
+    });
+}
+
+async function queryEmbedding(description: string): Promise<number[]> {
+  const [row] = await db
+    .select({ embedding: vectorItems.embedding })
+    .from(vectorItems)
+    .where(eq(vectorItems.description, description))
+    .limit(1);
+
+  if (!row?.embedding) throw new Error(`No embedding for '${description}'`);
+  return row.embedding;
+}
+
+async function semanticSearch(description: string): Promise<void> {
+  console.log(`\n--- Nearest neighbors of: '${description}' ---`);
+
+  const embedding = await queryEmbedding(description);
+  const distance = search.cosineDistance(vectorItems.embedding, embedding);
+
+  for (const item of await db
+    .select({
+      description: vectorItems.description,
+      distance: sql<number>`(${distance})::float8`,
+    })
+    .from(vectorItems)
+    .where(search.all(vectorItems.id))
+    .orderBy(distance)
+    .limit(5)) {
+    console.log(
+      `  • ${item.description.padEnd(40)} (distance: ${item.distance.toFixed(4)})`,
+    );
+  }
+}
+
+async function filteredSemanticSearch(
+  description: string,
+  keyword: string,
+): Promise<void> {
+  console.log(
+    `\n--- Nearest neighbors of: '${description}' matching '${keyword}' ---`,
+  );
+
+  const embedding = await queryEmbedding(description);
+  const distance = search.cosineDistance(vectorItems.embedding, embedding);
+
+  for (const item of await db
+    .select({
+      description: vectorItems.description,
+      distance: sql<number>`(${distance})::float8`,
+    })
+    .from(vectorItems)
+    .where(search.matchAll(vectorItems.description, keyword))
+    .orderBy(distance)
+    .limit(5)) {
+    console.log(
+      `  • ${item.description.padEnd(40)} (distance: ${item.distance.toFixed(4)})`,
+    );
+  }
+}
+
+try {
+  await runVectorSearch();
+} finally {
+  await db
+    .execute(sql`DROP TABLE IF EXISTS vector_search_items CASCADE`)
+    .catch(() => undefined);
+  await closeDb();
+}

--- a/examples/vector-search.ts
+++ b/examples/vector-search.ts
@@ -1,27 +1,11 @@
-import { eq, sql } from "drizzle-orm";
-import { integer, pgTable, text } from "drizzle-orm/pg-core";
-import { readFile } from "node:fs/promises";
+import { sql } from "drizzle-orm";
 
-import { closeDb, db } from "./common.js";
-import { indexing, search } from "../src/index.js";
+import { closeDb, db, mockItems, setupMockItems } from "./common.js";
+import { search } from "../src/index.js";
 
-const vectorItems = pgTable(
-  "vector_search_items",
-  {
-    id: integer("id").primaryKey(),
-    description: text("description").notNull(),
-    embedding: indexing.vector("embedding", { dimensions: 384 }),
-  },
-  (table) => [
-    indexing
-      .paradedbIndex("vector_search_items_idx")
-      .on(
-        table.id,
-        table.description,
-        indexing.vectorField(table.embedding, "cosine"),
-      ),
-  ],
-);
+// In production, compute query embeddings with the same model that produced
+// the stored embeddings. This fixed vector stands in for that model.
+const queryEmbedding = [-0.02, 0.47, -0.76, 0.13, 0.34, 0.04, 0.19, -0.19];
 
 export async function runVectorSearch(): Promise<void> {
   console.log("=".repeat(60));
@@ -30,90 +14,27 @@ export async function runVectorSearch(): Promise<void> {
   console.log("\nTop-K nearest neighbors served by the paradedb index.");
   console.log("A @@@ predicate and a LIMIT are required for index pushdown.");
 
-  try {
-    await setupVectorItems();
-  } catch (error) {
-    console.log(
-      `\nSkipped: requires pg_search with vector support (${String(error)})`,
-    );
-    return;
-  }
+  await setupMockItems();
 
-  await semanticSearch("Sturdy hiking boots");
-  await filteredSemanticSearch("Sturdy hiking boots", "shoes");
+  await nearestNeighbors();
+  await filteredNearestNeighbors("Footwear");
 
   console.log("\n" + "=".repeat(60));
   console.log("Done!");
 }
 
-async function setupVectorItems(): Promise<void> {
-  await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
-  await db.execute(sql`DROP TABLE IF EXISTS vector_search_items CASCADE`);
-  await db.execute(sql`
-    CREATE TABLE vector_search_items (
-      id integer PRIMARY KEY,
-      description text NOT NULL,
-      embedding vector(384)
-    )
-  `);
+async function nearestNeighbors(): Promise<void> {
+  console.log("\n--- Nearest neighbors across all items ---");
 
-  await db.insert(vectorItems).values(await loadItems());
-
-  await db.execute(sql`
-    CREATE INDEX vector_search_items_idx ON vector_search_items
-    USING paradedb (id, description, embedding vector_cosine_ops)
-    WITH (key_field='id')
-  `);
-  console.log("\n✓ Indexed vector_search_items with a cosine vector field");
-}
-
-async function loadItems(): Promise<
-  { id: number; description: string; embedding: number[] }[]
-> {
-  const csv = await readFile(
-    new URL("./hybrid_rrf/mock_items_embeddings.csv", import.meta.url),
-    "utf8",
-  );
-
-  return csv
-    .trim()
-    .split("\n")
-    .slice(1)
-    .map((line) => {
-      const match = line.match(/^(\d+),(.*),"(\[.*\])"$/);
-      if (!match) throw new Error(`Invalid embedding CSV row: ${line}`);
-      return {
-        id: Number(match[1]),
-        description: match[2],
-        embedding: JSON.parse(match[3]) as number[],
-      };
-    });
-}
-
-async function queryEmbedding(description: string): Promise<number[]> {
-  const [row] = await db
-    .select({ embedding: vectorItems.embedding })
-    .from(vectorItems)
-    .where(eq(vectorItems.description, description))
-    .limit(1);
-
-  if (!row?.embedding) throw new Error(`No embedding for '${description}'`);
-  return row.embedding;
-}
-
-async function semanticSearch(description: string): Promise<void> {
-  console.log(`\n--- Nearest neighbors of: '${description}' ---`);
-
-  const embedding = await queryEmbedding(description);
-  const distance = search.cosineDistance(vectorItems.embedding, embedding);
+  const distance = search.cosineDistance(mockItems.embedding, queryEmbedding);
 
   for (const item of await db
     .select({
-      description: vectorItems.description,
+      description: mockItems.description,
       distance: sql<number>`(${distance})::float8`,
     })
-    .from(vectorItems)
-    .where(search.all(vectorItems.id))
+    .from(mockItems)
+    .where(search.all(mockItems.id))
     .orderBy(distance)
     .limit(5)) {
     console.log(
@@ -122,24 +43,18 @@ async function semanticSearch(description: string): Promise<void> {
   }
 }
 
-async function filteredSemanticSearch(
-  description: string,
-  keyword: string,
-): Promise<void> {
-  console.log(
-    `\n--- Nearest neighbors of: '${description}' matching '${keyword}' ---`,
-  );
+async function filteredNearestNeighbors(category: string): Promise<void> {
+  console.log(`\n--- Nearest neighbors in category '${category}' ---`);
 
-  const embedding = await queryEmbedding(description);
-  const distance = search.cosineDistance(vectorItems.embedding, embedding);
+  const distance = search.cosineDistance(mockItems.embedding, queryEmbedding);
 
   for (const item of await db
     .select({
-      description: vectorItems.description,
+      description: mockItems.description,
       distance: sql<number>`(${distance})::float8`,
     })
-    .from(vectorItems)
-    .where(search.matchAll(vectorItems.description, keyword))
+    .from(mockItems)
+    .where(search.term(mockItems.category, category))
     .orderBy(distance)
     .limit(5)) {
     console.log(
@@ -151,8 +66,5 @@ async function filteredSemanticSearch(
 try {
   await runVectorSearch();
 } finally {
-  await db
-    .execute(sql`DROP TABLE IF EXISTS vector_search_items CASCADE`)
-    .catch(() => undefined);
   await closeDb();
 }

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 examples=(
   quickstart.ts
+  faceted-search.ts
+  vector-search.ts
+  hybrid-rrf.ts
+  rag.ts
   autocomplete.ts
   more-like-this.ts
-  faceted-search.ts
-  hybrid-rrf.ts
-  vector-search.ts
-  rag.ts
 )
 
 if [ "$#" -gt 0 ]; then

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -7,6 +7,7 @@ examples=(
   more-like-this.ts
   faceted-search.ts
   hybrid-rrf.ts
+  vector-search.ts
   rag.ts
 )
 

--- a/src/indexing.ts
+++ b/src/indexing.ts
@@ -1,12 +1,19 @@
 import { sql, SQL, SQLWrapper } from "drizzle-orm";
-import { index, IndexBuilder, PgColumn } from "drizzle-orm/pg-core";
+import {
+  ExtraConfigColumn,
+  index,
+  IndexBuilder,
+  PgColumn,
+} from "drizzle-orm/pg-core";
 import {
   renderSearchTokenizer,
   renderTokenizer,
   Tokenizer,
 } from "./tokenizer.js";
 
-type IndexField = PgColumn | SQL;
+export { vector } from "drizzle-orm/pg-core";
+
+type IndexField = PgColumn | SQL | Omit<ExtraConfigColumn, "op">;
 
 export type ParadedbIndexOptions = {
   searchTokenizer?: Tokenizer;
@@ -36,6 +43,21 @@ export function paradedbIndex(
 
 export function paradedbField(field: SQLWrapper, tokenizer: Tokenizer): SQL {
   return sql`((${field})::${sql.raw(renderTokenizer(tokenizer))})`;
+}
+
+export type VectorMetric = "l2" | "cosine" | "ip";
+
+const vectorOpClasses: Record<VectorMetric, string> = {
+  l2: "vector_l2_ops",
+  cosine: "vector_cosine_ops",
+  ip: "vector_ip_ops",
+};
+
+export function vectorField(
+  column: ExtraConfigColumn,
+  metric: VectorMetric = "l2",
+): Omit<ExtraConfigColumn, "op"> {
+  return column.op(vectorOpClasses[metric]);
 }
 
 export function jsonText(column: SQLWrapper, key: string): SQL {

--- a/src/indexing.ts
+++ b/src/indexing.ts
@@ -13,7 +13,7 @@ import {
 
 export { vector } from "drizzle-orm/pg-core";
 
-type IndexField = PgColumn | SQL | Omit<ExtraConfigColumn, "op">;
+type IndexField = PgColumn | SQL;
 
 export type ParadedbIndexOptions = {
   searchTokenizer?: Tokenizer;
@@ -56,7 +56,7 @@ const vectorOpClasses: Record<VectorMetric, string> = {
 export function vectorField(
   column: ExtraConfigColumn,
   metric: VectorMetric = "l2",
-): Omit<ExtraConfigColumn, "op"> {
+): IndexField {
   return column.op(vectorOpClasses[metric]);
 }
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,6 +1,8 @@
 import { AnyColumn, SQL, sql, type SQLWrapper } from "drizzle-orm";
 import { Tokenizer, renderTokenizer } from "./tokenizer.js";
 
+export { cosineDistance, innerProduct, l2Distance } from "drizzle-orm";
+
 type SearchValue = string | string[] | SQLWrapper;
 
 export function boost(value: SearchValue, factor: number): SQL {

--- a/tests/db.ts
+++ b/tests/db.ts
@@ -7,3 +7,13 @@ const connectionString =
 
 export const client = postgres(connectionString);
 export const db = drizzle({ client });
+
+export async function supportsVectorSearch(): Promise<boolean> {
+  const [row] = await client`
+    SELECT count(*)::int AS count
+    FROM pg_opclass oc
+    JOIN pg_am am ON am.oid = oc.opcmethod
+    WHERE am.amname = 'paradedb' AND oc.opcname = 'vector_l2_ops'
+  `;
+  return row.count > 0;
+}

--- a/tests/db.ts
+++ b/tests/db.ts
@@ -7,13 +7,3 @@ const connectionString =
 
 export const client = postgres(connectionString);
 export const db = drizzle({ client });
-
-export async function supportsVectorSearch(): Promise<boolean> {
-  const [row] = await client`
-    SELECT count(*)::int AS count
-    FROM pg_opclass oc
-    JOIN pg_am am ON am.oid = oc.opcmethod
-    WHERE am.amname = 'paradedb' AND oc.opcname = 'vector_l2_ops'
-  `;
-  return row.count > 0;
-}

--- a/tests/indexing.test.ts
+++ b/tests/indexing.test.ts
@@ -12,7 +12,9 @@ import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 
 import { tokenizer, search, indexing } from "../src/index.js";
-import { client, db } from "./db.js";
+import { client, db, supportsVectorSearch } from "./db.js";
+
+const vectorSearchSupported = await supportsVectorSearch();
 
 afterAll(async () => {
   await client.end();
@@ -131,6 +133,21 @@ describe("ParadeDB indexing helpers", () => {
     await runStatements(statements);
   });
 
+  it("generates vector field index SQL with opclasses", async () => {
+    const statements = await generateVectorIndexStatements();
+
+    expect(statements[1]).toStrictEqual(
+      `CREATE INDEX "indexing_test_products_bm25_idx" ON "indexing_test_products" USING paradedb ("id",(("description")::pdb.simple),"embedding" vector_l2_ops,"embedding_cosine" vector_cosine_ops,"embedding_ip" vector_ip_ops) WITH (key_field=id);`,
+    );
+  });
+
+  it.skipIf(!vectorSearchSupported)(
+    "runs vector field index SQL (requires pg_search vector support)",
+    async () => {
+      await runStatements(await generateVectorIndexStatements());
+    },
+  );
+
   it("applies a paradedb index with drizzle-kit push", async () => {
     const tempDir = await mkdtemp(
       join(dirname(fileURLToPath(import.meta.url)), "drizzle-kit-"),
@@ -224,6 +241,34 @@ export default defineConfig({
     }
   }, 60_000);
 });
+
+async function generateVectorIndexStatements(): Promise<string[]> {
+  const products = pgTable(
+    "indexing_test_products",
+    {
+      id: integer("id").primaryKey(),
+      description: text("description"),
+      embedding: indexing.vector("embedding", { dimensions: 3 }),
+      embeddingCosine: indexing.vector("embedding_cosine", { dimensions: 3 }),
+      embeddingIp: indexing.vector("embedding_ip", { dimensions: 3 }),
+    },
+    (table) => [
+      indexing
+        .paradedbIndex("indexing_test_products_bm25_idx")
+        .on(
+          table.id,
+          indexing.paradedbField(table.description, tokenizer.simple()),
+          indexing.vectorField(table.embedding),
+          indexing.vectorField(table.embeddingCosine, "cosine"),
+          indexing.vectorField(table.embeddingIp, "ip"),
+        ),
+    ],
+  );
+
+  const prev = await generateDrizzleJson({});
+  const cur = await generateDrizzleJson({ products });
+  return generateMigration(prev, cur);
+}
 
 async function runStatements(statements: string[]) {
   await db.execute(sql.raw(`DROP TABLE IF EXISTS indexing_test_products`));

--- a/tests/indexing.test.ts
+++ b/tests/indexing.test.ts
@@ -12,9 +12,7 @@ import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 
 import { tokenizer, search, indexing } from "../src/index.js";
-import { client, db, supportsVectorSearch } from "./db.js";
-
-const vectorSearchSupported = await supportsVectorSearch();
+import { client, db } from "./db.js";
 
 afterAll(async () => {
   await client.end();
@@ -133,20 +131,15 @@ describe("ParadeDB indexing helpers", () => {
     await runStatements(statements);
   });
 
-  it("generates vector field index SQL with opclasses", async () => {
+  it("generates and runs vector field index SQL with opclasses", async () => {
     const statements = await generateVectorIndexStatements();
 
     expect(statements[1]).toStrictEqual(
-      `CREATE INDEX "indexing_test_products_bm25_idx" ON "indexing_test_products" USING paradedb ("id",(("description")::pdb.simple),"embedding" vector_l2_ops,"embedding_cosine" vector_cosine_ops,"embedding_ip" vector_ip_ops) WITH (key_field=id);`,
+      `CREATE INDEX "indexing_test_products_idx" ON "indexing_test_products" USING paradedb ("id",(("description")::pdb.simple),"embedding" vector_l2_ops,"embedding_cosine" vector_cosine_ops,"embedding_ip" vector_ip_ops) WITH (key_field=id);`,
     );
-  });
 
-  it.skipIf(!vectorSearchSupported)(
-    "runs vector field index SQL (requires pg_search vector support)",
-    async () => {
-      await runStatements(await generateVectorIndexStatements());
-    },
-  );
+    await runStatements(statements);
+  });
 
   it("applies a paradedb index with drizzle-kit push", async () => {
     const tempDir = await mkdtemp(
@@ -254,7 +247,7 @@ async function generateVectorIndexStatements(): Promise<string[]> {
     },
     (table) => [
       indexing
-        .paradedbIndex("indexing_test_products_bm25_idx")
+        .paradedbIndex("indexing_test_products_idx")
         .on(
           table.id,
           indexing.paradedbField(table.description, tokenizer.simple()),

--- a/tests/mock-items.ts
+++ b/tests/mock-items.ts
@@ -11,7 +11,12 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-import { paradedbField, paradedbIndex } from "../src/indexing.js";
+import {
+  paradedbField,
+  paradedbIndex,
+  vector,
+  vectorField,
+} from "../src/indexing.js";
 import * as tokenizer from "../src/tokenizer.js";
 
 const int4range = customType<{ data: string; driverData: string }>({
@@ -33,6 +38,7 @@ export const mockItems = pgTable(
     lastUpdatedDate: date("last_updated_date"),
     latestAvailableTime: time("latest_available_time"),
     weightRange: int4range("weight_range"),
+    embedding: vector("embedding", { dimensions: 8 }),
   },
   (table) => [
     paradedbIndex("mock_items_search_idx").on(
@@ -49,6 +55,7 @@ export const mockItems = pgTable(
       table.lastUpdatedDate,
       table.latestAvailableTime,
       table.weightRange,
+      vectorField(table.embedding),
     ),
   ],
 );

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -1,9 +1,9 @@
 import { and, desc, sql } from "drizzle-orm";
-import { integer, pgTable, serial, text } from "drizzle-orm/pg-core";
+import { pgTable, serial, text } from "drizzle-orm/pg-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { indexing, search, tokenizer } from "../src/index.js";
-import { client, db, supportsVectorSearch } from "./db.js";
+import { search, tokenizer } from "../src/index.js";
+import { client, db } from "./db.js";
 import { mockItems } from "./mock-items.js";
 import {
   MoreLikeThisDocumentOptions,
@@ -14,14 +14,6 @@ const mockItemsWithSerialId = pgTable("mock_items", {
   id: serial("id").primaryKey(),
   description: text("description"),
 });
-
-const vectorItems = pgTable("vector_search_items", {
-  id: integer("id").primaryKey(),
-  description: text("description"),
-  embedding: indexing.vector("embedding", { dimensions: 3 }),
-});
-
-const vectorSearchSupported = await supportsVectorSearch();
 
 beforeAll(async () => {
   await db.execute(sql`DROP TABLE IF EXISTS mock_items CASCADE`);
@@ -1231,108 +1223,81 @@ describe("ParadeDB query language", () => {
 });
 
 describe("vector search", () => {
-  beforeAll(async () => {
-    if (!vectorSearchSupported) return;
+  const queryVector = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    await db.execute(sql`DROP TABLE IF EXISTS vector_search_items`);
-    await db.execute(sql`
-      CREATE TABLE vector_search_items (
-        id integer PRIMARY KEY,
-        description text,
-        embedding vector(3)
-      )
-    `);
-    await db.execute(sql`
-      INSERT INTO vector_search_items VALUES
-        (1, 'red running shoes', '[1,0,0]'),
-        (2, 'blue sneakers', '[0.9,0.1,0]'),
-        (3, 'green hat', '[0,0,1]')
-    `);
-    await db.execute(sql`
-      CREATE INDEX vector_search_items_idx ON vector_search_items
-      USING paradedb (id, description, embedding vector_l2_ops)
-      WITH (key_field='id')
-    `);
-  });
-
-  afterAll(async () => {
-    if (!vectorSearchSupported) return;
-    await db.execute(sql`DROP TABLE IF EXISTS vector_search_items`);
-  });
-
-  it("generates top-k l2 vector search SQL", () => {
+  it("runs a top-k l2 vector search", async () => {
     const query = db
-      .select({ id: vectorItems.id })
-      .from(vectorItems)
-      .where(search.all(vectorItems.id))
-      .orderBy(search.l2Distance(vectorItems.embedding, [1, 0, 0]))
+      .select({ id: mockItems.id })
+      .from(mockItems)
+      .where(search.all(mockItems.id))
+      .orderBy(search.l2Distance(mockItems.embedding, queryVector))
+      .limit(5);
+
+    const generated = query.toSQL();
+
+    expect(generated.sql).toBe(
+      `select "id" from "mock_items" where "mock_items"."id" @@@ pdb.all() order by "mock_items"."embedding" <-> $1 limit $2`,
+    );
+    expect(generated.params).toStrictEqual([JSON.stringify(queryVector), 5]);
+
+    await query;
+  });
+
+  it("runs a top-k cosine vector search", async () => {
+    const query = db
+      .select({ id: mockItems.id })
+      .from(mockItems)
+      .where(search.all(mockItems.id))
+      .orderBy(search.cosineDistance(mockItems.embedding, queryVector))
+      .limit(5);
+
+    const generated = query.toSQL();
+
+    expect(generated.sql).toBe(
+      `select "id" from "mock_items" where "mock_items"."id" @@@ pdb.all() order by "mock_items"."embedding" <=> $1 limit $2`,
+    );
+    expect(generated.params).toStrictEqual([JSON.stringify(queryVector), 5]);
+
+    await query;
+  });
+
+  it("runs a top-k inner product vector search", async () => {
+    const query = db
+      .select({ id: mockItems.id })
+      .from(mockItems)
+      .where(search.all(mockItems.id))
+      .orderBy(search.innerProduct(mockItems.embedding, queryVector))
+      .limit(5);
+
+    const generated = query.toSQL();
+
+    expect(generated.sql).toBe(
+      `select "id" from "mock_items" where "mock_items"."id" @@@ pdb.all() order by "mock_items"."embedding" <#> $1 limit $2`,
+    );
+    expect(generated.params).toStrictEqual([JSON.stringify(queryVector), 5]);
+
+    await query;
+  });
+
+  it("runs a filtered vector search", async () => {
+    const query = db
+      .select({ id: mockItems.id })
+      .from(mockItems)
+      .where(search.matchAny(mockItems.description, "shoes sneakers"))
+      .orderBy(search.l2Distance(mockItems.embedding, queryVector))
       .limit(2);
 
     const generated = query.toSQL();
 
     expect(generated.sql).toBe(
-      `select "id" from "vector_search_items" where "vector_search_items"."id" @@@ pdb.all() order by "vector_search_items"."embedding" <-> $1 limit $2`,
+      `select "id" from "mock_items" where "mock_items"."description" ||| $1 order by "mock_items"."embedding" <-> $2 limit $3`,
     );
-    expect(generated.params).toStrictEqual(["[1,0,0]", 2]);
+    expect(generated.params).toStrictEqual([
+      "shoes sneakers",
+      JSON.stringify(queryVector),
+      2,
+    ]);
+
+    await query;
   });
-
-  it("generates top-k cosine vector search SQL", () => {
-    const query = db
-      .select({ id: vectorItems.id })
-      .from(vectorItems)
-      .where(search.all(vectorItems.id))
-      .orderBy(search.cosineDistance(vectorItems.embedding, [1, 0, 0]))
-      .limit(2);
-
-    const generated = query.toSQL();
-
-    expect(generated.sql).toBe(
-      `select "id" from "vector_search_items" where "vector_search_items"."id" @@@ pdb.all() order by "vector_search_items"."embedding" <=> $1 limit $2`,
-    );
-    expect(generated.params).toStrictEqual(["[1,0,0]", 2]);
-  });
-
-  it("generates top-k inner product vector search SQL", () => {
-    const query = db
-      .select({ id: vectorItems.id })
-      .from(vectorItems)
-      .where(search.all(vectorItems.id))
-      .orderBy(search.innerProduct(vectorItems.embedding, [1, 0, 0]))
-      .limit(2);
-
-    const generated = query.toSQL();
-
-    expect(generated.sql).toBe(
-      `select "id" from "vector_search_items" where "vector_search_items"."id" @@@ pdb.all() order by "vector_search_items"."embedding" <#> $1 limit $2`,
-    );
-    expect(generated.params).toStrictEqual(["[1,0,0]", 2]);
-  });
-
-  it.skipIf(!vectorSearchSupported)(
-    "runs a top-k vector search (requires pg_search vector support)",
-    async () => {
-      const rows = await db
-        .select({ id: vectorItems.id })
-        .from(vectorItems)
-        .where(search.all(vectorItems.id))
-        .orderBy(search.l2Distance(vectorItems.embedding, [1, 0, 0]))
-        .limit(2);
-
-      expect(rows.map((row) => row.id)).toStrictEqual([1, 2]);
-    },
-  );
-
-  it.skipIf(!vectorSearchSupported)(
-    "runs a filtered vector search (requires pg_search vector support)",
-    async () => {
-      const rows = await db
-        .select({ id: vectorItems.id })
-        .from(vectorItems)
-        .where(search.matchAny(vectorItems.description, "shoes sneakers"))
-        .orderBy(search.l2Distance(vectorItems.embedding, [0, 0, 1]))
-        .limit(2);
-
-      expect(rows.map((row) => row.id)).toStrictEqual([2, 1]);
-    },
-  );
 });

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -1,9 +1,9 @@
 import { and, desc, sql } from "drizzle-orm";
-import { pgTable, serial, text } from "drizzle-orm/pg-core";
+import { integer, pgTable, serial, text } from "drizzle-orm/pg-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { search, tokenizer } from "../src/index.js";
-import { client, db } from "./db.js";
+import { indexing, search, tokenizer } from "../src/index.js";
+import { client, db, supportsVectorSearch } from "./db.js";
 import { mockItems } from "./mock-items.js";
 import {
   MoreLikeThisDocumentOptions,
@@ -14,6 +14,14 @@ const mockItemsWithSerialId = pgTable("mock_items", {
   id: serial("id").primaryKey(),
   description: text("description"),
 });
+
+const vectorItems = pgTable("vector_search_items", {
+  id: integer("id").primaryKey(),
+  description: text("description"),
+  embedding: indexing.vector("embedding", { dimensions: 3 }),
+});
+
+const vectorSearchSupported = await supportsVectorSearch();
 
 beforeAll(async () => {
   await db.execute(sql`DROP TABLE IF EXISTS mock_items CASCADE`);
@@ -1220,4 +1228,111 @@ describe("ParadeDB query language", () => {
     });
     expect(result).toBe(`pdb.mytokenizer(true,false,'someBool=true')`);
   });
+});
+
+describe("vector search", () => {
+  beforeAll(async () => {
+    if (!vectorSearchSupported) return;
+
+    await db.execute(sql`DROP TABLE IF EXISTS vector_search_items`);
+    await db.execute(sql`
+      CREATE TABLE vector_search_items (
+        id integer PRIMARY KEY,
+        description text,
+        embedding vector(3)
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO vector_search_items VALUES
+        (1, 'red running shoes', '[1,0,0]'),
+        (2, 'blue sneakers', '[0.9,0.1,0]'),
+        (3, 'green hat', '[0,0,1]')
+    `);
+    await db.execute(sql`
+      CREATE INDEX vector_search_items_idx ON vector_search_items
+      USING paradedb (id, description, embedding vector_l2_ops)
+      WITH (key_field='id')
+    `);
+  });
+
+  afterAll(async () => {
+    if (!vectorSearchSupported) return;
+    await db.execute(sql`DROP TABLE IF EXISTS vector_search_items`);
+  });
+
+  it("generates top-k l2 vector search SQL", () => {
+    const query = db
+      .select({ id: vectorItems.id })
+      .from(vectorItems)
+      .where(search.all(vectorItems.id))
+      .orderBy(search.l2Distance(vectorItems.embedding, [1, 0, 0]))
+      .limit(2);
+
+    const generated = query.toSQL();
+
+    expect(generated.sql).toBe(
+      `select "id" from "vector_search_items" where "vector_search_items"."id" @@@ pdb.all() order by "vector_search_items"."embedding" <-> $1 limit $2`,
+    );
+    expect(generated.params).toStrictEqual(["[1,0,0]", 2]);
+  });
+
+  it("generates top-k cosine vector search SQL", () => {
+    const query = db
+      .select({ id: vectorItems.id })
+      .from(vectorItems)
+      .where(search.all(vectorItems.id))
+      .orderBy(search.cosineDistance(vectorItems.embedding, [1, 0, 0]))
+      .limit(2);
+
+    const generated = query.toSQL();
+
+    expect(generated.sql).toBe(
+      `select "id" from "vector_search_items" where "vector_search_items"."id" @@@ pdb.all() order by "vector_search_items"."embedding" <=> $1 limit $2`,
+    );
+    expect(generated.params).toStrictEqual(["[1,0,0]", 2]);
+  });
+
+  it("generates top-k inner product vector search SQL", () => {
+    const query = db
+      .select({ id: vectorItems.id })
+      .from(vectorItems)
+      .where(search.all(vectorItems.id))
+      .orderBy(search.innerProduct(vectorItems.embedding, [1, 0, 0]))
+      .limit(2);
+
+    const generated = query.toSQL();
+
+    expect(generated.sql).toBe(
+      `select "id" from "vector_search_items" where "vector_search_items"."id" @@@ pdb.all() order by "vector_search_items"."embedding" <#> $1 limit $2`,
+    );
+    expect(generated.params).toStrictEqual(["[1,0,0]", 2]);
+  });
+
+  it.skipIf(!vectorSearchSupported)(
+    "runs a top-k vector search (requires pg_search vector support)",
+    async () => {
+      const rows = await db
+        .select({ id: vectorItems.id })
+        .from(vectorItems)
+        .where(search.all(vectorItems.id))
+        .orderBy(search.l2Distance(vectorItems.embedding, [1, 0, 0]))
+        .limit(2);
+
+      expect(rows.map((row) => row.id)).toStrictEqual([1, 2]);
+    },
+  );
+
+  it.skipIf(!vectorSearchSupported)(
+    "runs a filtered vector search (requires pg_search vector support)",
+    async () => {
+      const rows = await db
+        .select({ id: vectorItems.id })
+        .from(vectorItems)
+        .where(search.matchAny(vectorItems.description, "shoes sneakers"))
+        .orderBy(search.l2Distance(vectorItems.embedding, [0, 0, 1]))
+        .limit(2);
+
+      expect(rows.map((row) => row.id)).toStrictEqual([2, 1]);
+    },
+  );
 });


### PR DESCRIPTION
## What

Implements paradedb/paradedb#5685: vector search support with zero new dependencies.

- Reuses drizzle-orm core's pgvector `vector()` column type and `l2Distance`/`cosineDistance`/`innerProduct` helpers, re-exported from this package
- New `indexing.vectorField(column, metric?)` emitting vector opclasses (`vector_l2_ops` default) inside `USING bm25` index DDL
- Docs, `examples/vector-search.ts`, and capability-gated integration tests

## Why

ParadeDB indexes pgvector columns inside the bm25 index, so users should get the full query surface from this package alone — no pgvector-node needed.

## Tests

77 passed / 3 skipped against 0.24.2 (vector integration tests gate on the bm25 vector opclass existing); all 80 pass against a dev pg_search build off `mvp/vector-search`. typecheck/prettier/markdownlint clean.