### PR TITLE
fix(deps): bump postcss to >=8.5.18 to resolve security alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   vite@>=8.0.0 <8.0.16: '>=8.0.16'
+  postcss@<8.5.18: '>=8.5.18'
 
 importers:
 
@@ -33,7 +34,7 @@ importers:
         version: 3.9.4
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.1)(typescript@7.0.2)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(typescript@7.0.2)
       tsx:
         specifier: ^4.22.3
         version: 4.23.1
@@ -1025,8 +1026,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1060,7 +1061,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.18'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -1073,8 +1074,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.9:
@@ -1180,7 +1181,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.18'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -1912,7 +1913,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   object-assign@4.1.1: {}
 
@@ -1932,17 +1933,17 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.1):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.16
+      postcss: 8.5.25
       tsx: 4.23.1
 
-  postcss@8.5.16:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2062,7 +2063,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.1)(typescript@7.0.2):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(typescript@7.0.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -2073,7 +2074,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.1)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)
       resolve-from: 5.0.0
       rollup: 4.62.0
       source-map: 0.7.6
@@ -2082,7 +2083,7 @@ snapshots:
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.25
       typescript: 7.0.2
     transitivePeerDependencies:
       - jiti
@@ -2127,7 +2128,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.25
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 overrides:
   esbuild@>=0.17.0 <0.28.1: ">=0.28.1"
   vite@>=8.0.0 <8.0.16: ">=8.0.16"
+  postcss@<8.5.18: ">=8.5.18"
 
 # pnpm 11 hard-fails (ERR_PNPM_IGNORED_BUILDS) on unapproved build scripts;
 # esbuild (used by tsup/vitest) needs to compile, so allow it explicitly.


### PR DESCRIPTION
Resolves Dependabot alert [#5](https://github.com/paradedb/drizzle-paradedb/security/dependabot/5) — [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (high): PostCSS path traversal in previous source map auto-loading (`sourceMappingURL`), leading to arbitrary `.map` file disclosure. Patched in 8.5.18.

## What

`postcss` is a transitive dev dependency, reached three ways:

- `tsup` → `postcss-load-config`
- `tsup` directly
- `vitest` → `vite`

The lockfile pinned it at 8.5.16. `pnpm update postcss -r` does not re-resolve a transitive pin, so this adds an override in `pnpm-workspace.yaml`, matching the existing pattern already used there for `esbuild` and `vite`:

```yaml
postcss@<8.5.18: ">=8.5.18"
```

`postcss` now resolves to **8.5.25**. All parent packages accept `^8`, so nothing is forced outside its declared range.

## Verification

- `pnpm test` — 73/73 passing across 3 test files, against a fresh ParadeDB 0.24.2-pg18 container
- `pnpm typecheck` — clean

## Notes

- **`pnpm build` fails, but it is pre-existing and unrelated to this change.** Confirmed by stashing this change and rebuilding on a clean tree — same failure. `rollup-plugin-dts@6.1.1` bundles its own `typescript@5.7.3` and crashes on `useCaseSensitiveFileNames` during `.d.ts` generation, against the repo's `typescript@^7.0.2`. The JS bundle builds fine; only declaration output breaks. Since `package.json` ships `dist` with a `types` entry, this likely blocks a release and is worth a separate issue.
- **No changelog entry.** This is a dev-only transitive dependency that never reaches the published `dist`, and the two prior security overrides (#17 esbuild, #18 vite) set the precedent of not recording these. Happy to add one under `Unreleased` if preferred.

https://claude.ai/code/session_016KXgARhDY768pkdfG1dfBS