### PR TITLE
feat: support vector index build options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Added
+
+- Vector index build options on `paradedbIndex`: `centroidRatio`, `trainingSamplesPerCentroid`, and `clusterReplication`, emitted as `centroid_ratio`, `training_samples_per_centroid`, and `cluster_replication` in the index `WITH` clause.
+
 ## [0.3.0] - 2025-08-04
 
 ### Added

--- a/src/indexing.ts
+++ b/src/indexing.ts
@@ -17,6 +17,9 @@ type IndexField = PgColumn | SQL;
 
 export type ParadedbIndexOptions = {
   searchTokenizer?: Tokenizer;
+  centroidRatio?: number;
+  trainingSamplesPerCentroid?: number;
+  clusterReplication?: number;
 };
 
 export function paradedbIndex(
@@ -32,6 +35,17 @@ export function paradedbIndex(
         withOptions.search_tokenizer = quote(
           renderSearchTokenizer(options.searchTokenizer),
         );
+      }
+      if (options.centroidRatio !== undefined) {
+        withOptions.centroid_ratio = String(options.centroidRatio);
+      }
+      if (options.trainingSamplesPerCentroid !== undefined) {
+        withOptions.training_samples_per_centroid = String(
+          options.trainingSamplesPerCentroid,
+        );
+      }
+      if (options.clusterReplication !== undefined) {
+        withOptions.cluster_replication = String(options.clusterReplication);
       }
 
       return index(name)

--- a/tests/indexing.test.ts
+++ b/tests/indexing.test.ts
@@ -141,6 +141,32 @@ describe("ParadeDB indexing helpers", () => {
     await runStatements(statements);
   });
 
+  it("generates and runs vector index SQL with all build options", async () => {
+    const statements = await generateVectorIndexStatements({
+      centroidRatio: 0.01,
+      trainingSamplesPerCentroid: 32,
+      clusterReplication: 1,
+    });
+
+    expect(statements[1]).toStrictEqual(
+      `CREATE INDEX "indexing_test_products_idx" ON "indexing_test_products" USING paradedb ("id",(("description")::pdb.simple),"embedding" vector_l2_ops,"embedding_cosine" vector_cosine_ops,"embedding_ip" vector_ip_ops) WITH (key_field=id, centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=1);`,
+    );
+
+    await runStatements(statements);
+  });
+
+  it("generates and runs vector index SQL with a single build option", async () => {
+    const statements = await generateVectorIndexStatements({
+      centroidRatio: 0.5,
+    });
+
+    expect(statements[1]).toStrictEqual(
+      `CREATE INDEX "indexing_test_products_idx" ON "indexing_test_products" USING paradedb ("id",(("description")::pdb.simple),"embedding" vector_l2_ops,"embedding_cosine" vector_cosine_ops,"embedding_ip" vector_ip_ops) WITH (key_field=id, centroid_ratio=0.5);`,
+    );
+
+    await runStatements(statements);
+  });
+
   it("applies a paradedb index with drizzle-kit push", async () => {
     const tempDir = await mkdtemp(
       join(dirname(fileURLToPath(import.meta.url)), "drizzle-kit-"),
@@ -235,7 +261,9 @@ export default defineConfig({
   }, 60_000);
 });
 
-async function generateVectorIndexStatements(): Promise<string[]> {
+async function generateVectorIndexStatements(
+  options: indexing.ParadedbIndexOptions = {},
+): Promise<string[]> {
   const products = pgTable(
     "indexing_test_products",
     {
@@ -247,7 +275,7 @@ async function generateVectorIndexStatements(): Promise<string[]> {
     },
     (table) => [
       indexing
-        .paradedbIndex("indexing_test_products_idx")
+        .paradedbIndex("indexing_test_products_idx", options)
         .on(
           table.id,
           indexing.paradedbField(table.description, tokenizer.simple()),


### PR DESCRIPTION
Exposes pg_search 0.25.0+ vector index build options (`centroid_ratio`, `training_samples_per_centroid`, `cluster_replication`) on `paradedbIndex`, so they can be set without raw SQL. They are emitted in the index `WITH` clause alongside `key_field`; values are validated server-side.

```ts
indexing
  .paradedbIndex("search_idx", {
    centroidRatio: 0.01,
    trainingSamplesPerCentroid: 32,
    clusterReplication: 1,
  })
  .on(table.id, indexing.vectorField(table.embedding, "cosine"));
```