### PR TITLE
chore: Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.4.0] - 2026-08-04
 
 ### Added
 
 - Vector index build options on `paradedbIndex`: `centroidRatio`, `trainingSamplesPerCentroid`, and `clusterReplication`, emitted as `centroid_ratio`, `training_samples_per_centroid`, and `cluster_replication` in the index `WITH` clause.
 
-## [0.3.0] - 2025-08-04
+## [0.3.0] - 2026-08-04
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradedb/drizzle-paradedb",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The official Drizzle integration for ParadeDB",
   "keywords": [
     "paradedb",


### PR DESCRIPTION
Promotes the Unreleased changelog section to 0.4.0 and bumps the package version for release.