### PR TITLE
fix(examples): use ParadeDB vector search in the hybrid RRF example

### DIFF
--- a/examples/hybrid-rrf.ts
+++ b/examples/hybrid-rrf.ts
@@ -83,8 +83,6 @@ async function hybridSearch(
       .orderBy(desc(search.score(mockItems.id)))
       .limit(topK),
   );
-  // The search.all() predicate is required: without a @@@ predicate the index
-  // cannot serve the query and Postgres falls back to a sequential scan.
   const semantic = db.$with("semantic").as(
     db
       .select({

--- a/examples/hybrid-rrf.ts
+++ b/examples/hybrid-rrf.ts
@@ -83,6 +83,8 @@ async function hybridSearch(
       .orderBy(desc(search.score(mockItems.id)))
       .limit(topK),
   );
+  // The search.all() predicate is required: without a @@@ predicate the index
+  // cannot serve the query and Postgres falls back to a sequential scan.
   const semantic = db.$with("semantic").as(
     db
       .select({
@@ -92,6 +94,7 @@ async function hybridSearch(
         ),
       })
       .from(mockItems)
+      .where(search.all(mockItems.id))
       .orderBy(vectorDistance)
       .limit(topK),
   );


### PR DESCRIPTION
The recent vector search work put the vector column inside the ParadeDB index in every ORM, but some examples still query it the old way. This fixes the ones in this repo. Companion PRs are open in the other affected repos; sqlalchemy needed no change.

## The problem

For the ParadeDB index to serve a vector query, three things are required together: a `@@@` predicate, a distance operator matching the index opclass metric, and a `LIMIT`. Drop the `@@@` predicate and the query still returns correct rows, so nothing fails loudly — it just silently stops using the index and becomes a sequential scan plus a sort. That is exactly the vanilla pgvector behavior these examples are meant to show you how to avoid.

## Verification

Measured with `EXPLAIN` against ParadeDB 0.25.0. Before:

```text
Limit
  ->  Sort
        Sort Key: ((embedding <=> '[...]'::vector))
        ->  Seq Scan on mock_items
```

After:

```text
Limit
  ->  Custom Scan (ParadeDB Base Scan) on mock_items
        Table: mock_items
        Index: search_idx
        Exec Method: TopKScanExecState
        Scores: false
           TopK Order By: embedding <=> vector asc
           TopK Limit: 20
        Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
```

Every changed example was run end to end against a live ParadeDB container and produces sensible rankings.

## What changed here

**`examples/hybrid-rrf.ts`** — the semantic CTE had no `@@@` predicate. Adds `search.all(mockItems.id)`, matching what the sqlalchemy and efcore hybrid examples already do.

`pnpm format:check` and `pnpm typecheck` pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4
