### PR TITLE
docs: spell out Retrieval-Augmented Generation and name pg_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](htt
 | Node       | 22.12+                                                             |
 | Drizzle    | 1.0+                                                               |
 | ParadeDB   | 0.25.0+                                                            |
-| PostgreSQL | 15+ (with ParadeDB extension)                                      |
+| PostgreSQL | 15+ (with the ParadeDB pg_search extension)                        |
 | pgvector   | Required for vector search (included in the ParadeDB Docker image) |
 
 ## Examples
@@ -54,7 +54,7 @@ The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](htt
 - [Vector Search](examples/vector-search.ts)
 - [Faceted Search](examples/faceted-search.ts)
 - [Hybrid Search (RRF)](examples/hybrid-rrf.ts)
-- [RAG](examples/rag.ts)
+- [Retrieval-Augmented Generation (RAG)](examples/rag.ts)
 - [Autocomplete](examples/autocomplete.ts)
 - [More Like This](examples/more-like-this.ts)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ Requires the `pgvector` extension, which is included in the ParadeDB Docker imag
 pnpm examples hybrid-rrf.ts
 ```
 
-## RAG (`rag.ts`)
+## Retrieval-Augmented Generation (RAG) (`rag.ts`)
 
 A small question-answering flow. Retrieves relevant context with ParadeDB, then sends it to an LLM so answers are grounded in your own data.
 


### PR DESCRIPTION
- Expands **RAG** to **Retrieval-Augmented Generation (RAG)** in the README example list and the `examples/README.md` section heading, matching how **Hybrid Search (RRF)** already spells out its acronym.
- Names the extension explicitly in the PostgreSQL requirements row: `15+ (with the ParadeDB pg_search extension)`.

Applied identically across all five ORM integrations. Table column widths were re-flowed by prettier. markdownlint, prettier and codespell pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4