### PR TITLE
fix: give each ORM integration its own ParadeDB container name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To run a subset of tests, pass vitest selectors:
 pnpm test tests/queries.test.ts -t "score"
 ```
 
-`pnpm db:setup` starts a ParadeDB container via Docker and exports `DATABASE_URL`. The default container name is `drizzle-paradedb` on port `5432`.
+`pnpm db:setup` starts a ParadeDB container via Docker and exports `DATABASE_URL`. The default container is `drizzle-paradedb` on port `5432`. Each ParadeDB ORM integration uses its own container name, so a container from another repo is never reused by mistake. They all bind port `5432`, so stop one before starting another.
 
 Some integration tests require newer pg_search versions and are skipped automatically if the feature is not available.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To run a subset of tests, pass vitest selectors:
 pnpm test tests/queries.test.ts -t "score"
 ```
 
-`pnpm db:setup` starts a ParadeDB container via Docker and exports `DATABASE_URL`. The default container is `drizzle-paradedb` on port `5432`. Each ParadeDB ORM integration uses its own container name, so a container from another repo is never reused by mistake. They all bind port `5432`, so stop one before starting another.
+`pnpm db:setup` starts a ParadeDB container via Docker and exports `DATABASE_URL`. The default container is `drizzle-paradedb` on port `5432`.
 
 Some integration tests require newer pg_search versions and are skipped automatically if the feature is not available.
 


### PR DESCRIPTION
## The problem

django, rails and efcore all defaulted to the **same container name** — `paradedb-integration`. Working on two of them locally meant the second repo silently reused the first's container, with the first repo's schema and data. Nothing errors; you just get wrong results.

## The fix

Each repo names its container after itself:

| Repo | Container | Port |
|---|---|---|
| django | `django-paradedb` | 5432 |
| sqlalchemy | `sqlalchemy-paradedb` | 5432 |
| drizzle | `drizzle-paradedb` | 5432 |
| rails | `rails-paradedb` | 5432 |
| efcore | `efcore-paradedb` | 5432 |

All five keep binding `5432`, so starting a second while another runs now fails loudly on the port rather than quietly attaching to the wrong database. sqlalchemy moves from `5443` to `5432` to match. Both values remain overridable via `PARADEDB_CONTAINER_NAME` and `PARADEDB_PORT`, and `CONTRIBUTING.md` documents the pair in every repo.

## A latent bug this surfaced

efcore's `scripts/run_paradedb.sh` set `DATABASE_URL` but **never exported it**, unlike django, sqlalchemy and rails. Child processes never saw it, so the examples fell through to the `PGHOST`/`PGPORT` defaults in `ExampleSetup.ConnectionString` and reached the database only because those defaults happen to be `localhost:5432`. Correct now regardless of how the port is configured.

## Verification

- django: full suite (322 tests) passes against `django-paradedb`
- efcore: Quickstart example runs against `efcore-paradedb` via the newly exported `DATABASE_URL` (.NET 10 container)
- efcore's own tests are unaffected — they provision their database with Testcontainers
- shellcheck, beautysh, prettier, markdownlint and codespell pass

Note for reviewers: anyone with an existing `paradedb-integration` container will get a fresh one on first run. Harmless for throwaway dev data, but worth knowing.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4