### PR TITLE
docs: standardize prek commands and container note in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ cd drizzle-paradedb
 pnpm install
 
 # Install prek hooks
-pnpm dlx @j178/prek install
+uvx prek install
 ```
 
 ### Running Tests
@@ -74,8 +74,8 @@ pnpm typecheck
 pnpm build
 
 # Pre-commit hooks (markdownlint, codespell, etc.)
-pnpm dlx @j178/prek install
-pnpm dlx @j178/prek run --all-files
+uvx prek install
+uvx prek run --all-files
 ```
 
 ### API and Packaging Consistency Checks
@@ -93,7 +93,7 @@ All changes to drizzle-paradedb happen through GitHub Pull Requests. Here is the
 1. Before working on a change, please check if there is already a GitHub issue open for it.
 2. If there is not, please open an issue first. This gives the community visibility into your work and allows others to make suggestions and leave comments.
 3. Fork the drizzle-paradedb repo and branch out from the `main` branch.
-4. Install [prek](https://prek.j178.dev/quickstart/#already-using-pre-commit) hooks within your fork with `pnpm dlx @j178/prek install` to ensure code quality and consistency with upstream.
+4. Install [prek](https://prek.j178.dev/quickstart/#already-using-pre-commit) hooks within your fork with `uvx prek install` to ensure code quality and consistency with upstream.
 5. Make your changes. If you've added new functionality, please add tests. We will not merge a feature without appropriate tests.
 6. Open a pull request towards the `main` branch. Ensure that all tests and checks pass. Note that the drizzle-paradedb repository has pull request title linting in place and follows the [Conventional Commits spec](https://www.conventionalcommits.org/).
 7. Congratulations! Our team will review your pull request.


### PR DESCRIPTION
Two things drifted after the container-rename merge.

## prek was invoked three different ways

Across the five repos, in four places each:

| Repo | Was |
|---|---|
| django, sqlalchemy | `uvx prek install` |
| drizzle | `pnpm dlx @j178/prek install` |
| rails, efcore | `prek install -f` |

All now use `uvx prek install` / `uvx prek run --all-files`. Every repo already requires uv — each `CONTRIBUTING.md` documents `uv run --with json5 scripts/check_api_coverage.py`, and each CI uses `astral-sh/setup-uv` in three or more workflows — so `uvx` needs neither a global prek install nor pnpm.

## The container note survived in only three repos

`The default container is <name> on port 5432.` was kept in django, sqlalchemy and drizzle but dropped from rails and efcore. Both now carry it, phrased identically to the other three.

## Result

Every `CONTRIBUTING.md` section that is not inherently toolchain-specific is now byte-identical across all five repos (comparing with the package name normalized):

```
## Technical Info                    IDENTICAL
### Selecting GitHub Issues          IDENTICAL
### Claiming GitHub Issues           IDENTICAL
### Pull Request Workflow            IDENTICAL
### Changelog                        IDENTICAL
## Legal Info                        IDENTICAL
### Contributor License Agreement    IDENTICAL
### License                          IDENTICAL
```

Development Setup, Running Tests, Linting and Formatting, API Checks and Documentation legitimately differ — they describe different toolchains.

prettier, markdownlint and codespell pass in all five.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4