### PR TITLE
test: add a packaging smoke test to every ORM integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,26 @@ jobs:
 
       - name: Check API coverage
         run: uv run --with json5 scripts/check_api_coverage.py
+
+  package-smoke:
+    name: Package Install Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Package install smoke test
+        run: bash scripts/smoke_package_install.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ Run these before opening a PR if your change touches SQL wrappers, API constants
 
 ```bash
 uv run --with json5 scripts/check_api_coverage.py
+bash scripts/smoke_package_install.sh
 ```
 
 ### Pull Request Workflow

--- a/scripts/smoke_package_install.sh
+++ b/scripts/smoke_package_install.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# smoke_package_install.sh
+#
+# Builds the npm package, installs the packed tarball into a throwaway project,
+# and exercises the public API from it. This catches packaging problems the test
+# suite cannot see, because the tests import from src/ while consumers get only
+# whatever `files` and `exports` actually publish.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+PKG_NAME="$(node -p "require('./package.json').name")"
+VERSION="$(node -p "require('./package.json').version")"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/drizzle-paradedb-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+echo "Building ${PKG_NAME}@${VERSION}..."
+pnpm build >/dev/null
+
+npm pack --pack-destination "${WORK_DIR}" >/dev/null
+TARBALL="$(find "${WORK_DIR}" -maxdepth 1 -name '*.tgz' | head -1)"
+
+if [[ -z "${TARBALL}" ]]; then
+  echo "❌ npm pack produced no tarball" >&2
+  exit 1
+fi
+
+# The published tarball must carry the build output and its type declarations.
+for entry in package/dist/index.js package/dist/index.d.ts; do
+  if ! tar -tzf "${TARBALL}" | grep -Fxq "${entry}"; then
+    echo "❌ ${entry} missing from the packed tarball" >&2
+    exit 1
+  fi
+done
+
+APP_DIR="${WORK_DIR}/app"
+mkdir -p "${APP_DIR}"
+cd "${APP_DIR}"
+
+cat > package.json <<'JSON'
+{
+  "name": "drizzle-paradedb-smoke",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}
+JSON
+
+npm install --no-audit --no-fund --silent "${TARBALL}" >/dev/null
+
+cat > smoke.mjs <<JSON
+import { integer, PgDialect, pgTable, text } from "drizzle-orm/pg-core";
+import { search } from "${PKG_NAME}";
+
+const mockItems = pgTable("mock_items", {
+  id: integer("id").primaryKey(),
+  description: text("description"),
+});
+
+const { sql } = new PgDialect().sqlToQuery(
+  search.matchAll(mockItems.description, "running shoes"),
+);
+
+if (!sql.includes("&&&")) {
+  console.error(\`Expected the ParadeDB match operator in: \${sql}\`);
+  process.exit(1);
+}
+
+console.log("✅ Package smoke install passed for ${PKG_NAME}@${VERSION}");
+JSON
+
+node smoke.mjs


### PR DESCRIPTION
drizzle and efcore had **no packaging check at all**. django and sqlalchemy had `smoke_wheel_install.sh`, rails had `smoke_gem_install.sh`; all three are now `scripts/smoke_package_install.sh`, so the file has the same name everywhere.

## Why this matters more than it sounds

A packaging smoke test catches a class of bug the test suite structurally **cannot**: the tests import from the source tree, while consumers get only what the published artifact actually contains.

Concretely, django and sqlalchemy force-include `api.json5` into the wheel and load it at import time to define every API constant. A regression there would ship a package that fails on import for every user, while CI stayed entirely green.

## What each script does

Each builds the real artifact, installs it into a throwaway project, and exercises the public API **from the installed copy**:

| Repo | Approach |
|---|---|
| django, sqlalchemy | build the wheel → install into a fresh venv → compile a query, assert `&&&` |
| drizzle | `pnpm build` → `npm pack` → assert `dist/index.js` and `dist/index.d.ts` are in the tarball → install into a scratch project → assert `PgDialect` renders `&&&` |
| rails | `gem build` → install into an isolated `GEM_HOME` → assert the Arel node is a ParadeDB match infix operation |
| efcore | `dotnet pack` → restore from a local feed into a scratch console project → assert `MatchAll`, `Score`, `Parse` are public statics on the packed assembly |

All five run in CI as **Package install smoke test**, and are documented under *API and Packaging Consistency Checks* — drizzle and efcore previously documented no packaging step.

## Verification

Every script exits 0 as-is:

```
django      ✅ Package smoke install passed for django-paradedb 0.12.0
sqlalchemy  ✅ Package smoke install passed for sqlalchemy-paradedb 0.10.0
drizzle     ✅ Package smoke install passed for @paradedb/drizzle-paradedb@0.4.0
rails       ✅ Package smoke install passed for rails-paradedb 0.11.0
efcore      ✅ Package smoke install passed for ParadeDB.EntityFrameworkCore 1.0.0
```

And they were **negative-tested**, so they aren't inert:

- breaking drizzle's `files` so `dist` isn't published → exit 1, `❌ package/dist/index.d.ts missing from the packed tarball`
- asking efcore for a method that doesn't exist → exit 1, `Expected public static ParadeDbFunctionsExtensions.ThisMethodDoesNotExist in the packed assembly`

rails ran in a Ruby 3.4 container and efcore in a .NET 10 container, since this machine has neither toolchain. shellcheck, beautysh, prettier, markdownlint and codespell all pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4