### PR TITLE
ci: run the package smoke test from each repo's existing validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,14 +100,6 @@ jobs:
       - name: Check API coverage
         run: uv run --with json5 scripts/check_api_coverage.py
 
-  package-smoke:
-    name: Package Install Smoke Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
 


### PR DESCRIPTION
The packaging smoke test landed in an inconsistent place across the five repos. This makes the rule uniform: **no repo has a dedicated job** — each runs it from the single-run validation job that already has the right toolchain.

| Repo | Job | Toolchain already there |
|---|---|---|
| django | `lint` | setup-python |
| sqlalchemy | `lint` | setup-python |
| drizzle | `check-api-coverage` | setup-python, **pnpm, setup-node** (added) |
| rails | `lint` | setup-python, setup-ruby |
| efcore | `lint` | **setup-dotnet 10.0.x** |

## efcore was passing by accident

Its smoke test needs `dotnet`, but `check-api-coverage` only sets up Python. It went green purely because GitHub runners ship a **preinstalled .NET** — at whatever version that happens to be, rather than the `10.0.x` the rest of the repo pins. A check that passes for the wrong reason is worse than one that fails, so this is the substantive fix here: it now runs from `lint`, which already sets up .NET 10.0.x for CSharpier.

## drizzle loses its dedicated job

drizzle has no `lint` job, so its single-run job is `check-api-coverage`, which gains pnpm and Node 22. (django's `lint` job likewise does more than lint — it runs API coverage and the smoke test too — so a validation job covering several checks is the existing convention.)

django, sqlalchemy and rails are unchanged; they were already correct.

## Verification

Both scripts re-run after the move:

```
drizzle_EXIT=0  ✅ Package smoke install passed for @paradedb/drizzle-paradedb@0.4.0
efcore_EXIT=0   ✅ Package smoke install passed for ParadeDB.EntityFrameworkCore 1.0.0
```

efcore ran in a .NET 10 container. Both workflow files parse as valid YAML and pass prettier.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4