### PR TITLE
ci: standardize the release workflow across ORM integrations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Validate version
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -80,24 +93,16 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "PACKAGE_NAME=${PACKAGE_NAME}" >> "$GITHUB_ENV"
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: pnpm
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Build package
         run: |
           pnpm build
           npm pack --dry-run
           echo "✅ Package built and validated"
+
+      - name: Publish to npm
+        run: |
+          npm publish --access public
+          echo "✅ Published ${PACKAGE_NAME} ${VERSION} to npm"
 
       - name: Determine if latest
         id: latest
@@ -105,7 +110,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           LATEST=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//' || echo "0.0.0")
-          if pnpm dlx semver -r ">${LATEST:-0.0.0}" "${VERSION}"; then
+          if npx --yes semver -r ">${LATEST:-0.0.0}" "${VERSION}"; then
             echo "is_latest=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_latest=false" >> "$GITHUB_OUTPUT"
@@ -115,17 +120,12 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
-          target_commitish: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
           prerelease: ${{ github.event.inputs.beta }}
           make_latest: ${{ steps.latest.outputs.is_latest }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Publish to npm
-        run: |
-          npm publish --access public
-          echo "✅ Published ${PACKAGE_NAME} ${VERSION} to npm"
 
       - name: Summary
         run: |


### PR DESCRIPTION
The five release workflows had drifted in ways that matter for a step that publishes packages.

## Publish now always precedes the GitHub Release

django, rails and efcore already did this; **sqlalchemy and drizzle created the release first**. Publishing to a registry is the irreversible half — if it fails, there shouldn't already be a GitHub Release announcing a version that was never published. The reverse failure (a published package with no GitHub Release yet) is trivially fixed by hand.

## rails and efcore never marked releases as latest

Neither had a `Determine if latest` step, and neither passed `make_latest`, so GitHub fell back to treating the newest release as latest. That's wrong precisely when it matters — publishing a patch for an older line would silently steal the "Latest" badge from a newer release. Both now compute it the same way the other three do.

## Also unified

So the five files differ only where the toolchains genuinely do:

- **One step sequence**: validate confirmation → checkout → set up toolchain → validate version → build package → publish → determine if latest → create GitHub Release → summary
- **Toolchain setup moved ahead of version validation** — required by rails and efcore, which read the version with `ruby` and `dotnet`; harmless for the others, which use `grep`
- **`Determine if latest` sits directly before its only consumer**
- **One vocabulary**: `Validate version`, `Build package`, `Create GitHub Release` — replacing `Validate version and release state`, `Build gem`, `Pack ParadeDB.EntityFrameworkCore`, `Create GitHub tag and release`
- **One latest-detection implementation**, using `npx --yes` instead of a separate `npm install semver`, with `$GITHUB_OUTPUT` quoted
- **`github.token`** everywhere, instead of a mix with `secrets.GITHUB_TOKEN`
- **`target_commitish: github.sha`** rather than `github.ref_name`, so the release points at the commit that was built rather than wherever the branch has moved since
- **sqlalchemy** attaches its built artifacts to the release like django, and builds/publishes through `uv` rather than pip-installing twine

## Verification

These workflows only run on `workflow_dispatch`, so **CI cannot exercise them** — worth a closer read than usual. Each file was checked to:

- parse as valid YAML
- expose the `latest` step id that `make_latest` references
- keep its publish credentials (`PYPI_TOKEN`, `NPM_TOKEN`, `RUBYGEMS_TOKEN`, `NUGET_API_KEY`) untouched

prettier and codespell pass in all five.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4