### PR TITLE
chore: standardize scripts/ and harden the ParadeDB container helper

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install markdownlint
-        run: npm install -g markdownlint-cli
+        run: npm install -g markdownlint-cli@0.45.0
 
       - name: Run Markdown Lint
         run: markdownlint "**/*.md" --ignore node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,7 @@ uvx prek install
 Run the tests to verify every change:
 
 ```bash
-pnpm db:setup
-pnpm test
+bash scripts/run_tests.sh
 ```
 
 To run a subset of tests, pass vitest selectors:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
-    "db:setup": "bash scripts/setup_db.sh",
+    "db:setup": "bash scripts/run_paradedb.sh",
     "examples": "bash scripts/run_examples.sh",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/run_paradedb.sh
+++ b/scripts/run_paradedb.sh
@@ -17,6 +17,15 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
+# A container left over from a failed run can exist without publishing the
+# port, in which case reusing it yields confusing connection errors. Drop it
+# so the normal creation path below builds a working one.
+if docker ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME" &&
+! docker port "$CONTAINER_NAME" 5432 2>/dev/null | grep -q ":${PORT}$"; then
+  echo "Container $CONTAINER_NAME exists but does not publish port ${PORT}; recreating it..."
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+fi
+
 if ! docker ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
   echo "Starting ParadeDB container $CONTAINER_NAME from $IMAGE..."
   docker run -d \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# run_tests.sh
+#
+# Runs the full test suite against a local ParadeDB instance. Starts the
+# container via scripts/run_paradedb.sh unless DATABASE_URL is already set.
+# Extra arguments are forwarded to vitest.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  # shellcheck source=/dev/null
+  source scripts/run_paradedb.sh
+fi
+
+pnpm test "$@"


### PR DESCRIPTION
Closes the remaining `scripts/` findings from the audit, and fixes two real bugs that surfaced while verifying them.

## Naming

- drizzle's `setup_db.sh` → **`run_paradedb.sh`**, which is what the other four call it and what every `CONTRIBUTING.md` already references. `pnpm db:setup` still works.
- Every repo now has **`scripts/run_tests.sh`** as a single entry point for the full suite. django already had one; sqlalchemy and rails gain a thin wrapper over their unit + integration scripts; drizzle and efcore gain one over their native runners.

## Bug 1 — stale containers were silently reused

A container left over from a failed run can exist **without publishing its port**. `run_paradedb.sh` matched it by name and reused it, so every connection failed with no indication why. This cost me time twice during this work.

It now checks the port mapping and recreates the container when it doesn't match:

```
Container django-paradedb exists but does not publish port 5432; recreating it...
Starting ParadeDB container django-paradedb from paradedb/paradedb:0.25.0-pg18...
```

Verified both directions: a container with no published port is detected and rebuilt, and a healthy one is still reused rather than needlessly recreated.

## Bug 2 — sqlalchemy and rails had a readiness race

Both probed with `pg_isready` over the **Unix socket** rather than TCP. During first-time initialization the ParadeDB image runs a temporary socket-only server, so the probe reported ready while the real server was still starting, and the suite then died with `server closed the connection unexpectedly`.

django, drizzle and efcore already passed `-h 127.0.0.1` and carried a comment explaining exactly this — the other two had drifted from it.

| | before | after |
|---|---|---|
| sqlalchemy, cold start | 8 passed, **176 errors** | **211 unit + 184 integration passed** |

## Prettier pinning

The four repos that `npm install -g prettier markdownlint-cli` did so **unpinned**, so a prettier major release would break markdown and YAML linting in four repos simultaneously. Now pinned to `prettier@3.9.6` and `markdownlint-cli@0.45.0` (matching the pre-commit rev). Verified those exact versions pass on current content in all five.

Note on the audit item "drizzle's two lint workflows differ": drizzle uses `pnpm exec prettier` because it pins prettier in `devDependencies`, so its lint agrees with its own `format:check`. That's **deliberate and better** than an unpinned global install, so I left it — forcing byte-identical files here would have made drizzle worse. Pinning the other four converges the behaviour instead.

## Verification

- django 322 passed · sqlalchemy 211 + 184 passed · drizzle 80 passed · efcore 119 passed (Testcontainers, .NET 10 container)
- `pnpm db:setup` still resolves after the rename
- shellcheck clean (bar pre-existing SC1091 sourcing notices), beautysh, prettier, markdownlint and codespell all pass

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4