### PR TITLE
chore: add vector and faceting package keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "bm25",
     "text search",
     "full text search",
-    "hybrid search"
+    "hybrid search",
+    "vector search",
+    "faceted search",
+    "facets"
   ],
   "homepage": "https://github.com/paradedb/drizzle-paradedb",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "hybrid search",
     "vector search",
     "faceted search",
-    "facets"
+    "facets",
+    "aggregations"
   ],
   "homepage": "https://github.com/paradedb/drizzle-paradedb",
   "bugs": {


### PR DESCRIPTION
Adds the missing vector-search and faceting keywords to the npm package metadata so it matches the integration's supported examples and GitHub topics.

Validation:
- parsed 'package.json' with 'jq'
- 'git diff --check'