### PR TITLE
chore: run Prettier before validators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
       - id: codespell
         args: ["--config", ".codespellrc", "--check-filenames"]
         exclude: ^pnpm-lock\.yaml$
+
   - repo: local
     hooks:
       - id: typecheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,14 @@ repos:
       - id: destroyed-symlinks
       - id: fix-byte-order-marker
 
+  - repo: local
+    hooks:
+      - id: format
+        name: pnpm format
+        entry: pnpm format
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
@@ -44,11 +52,6 @@ repos:
         exclude: ^pnpm-lock\.yaml$
   - repo: local
     hooks:
-      - id: format
-        name: pnpm format
-        entry: pnpm format
-        language: system
-        pass_filenames: false
       - id: typecheck
         name: pnpm typecheck
         entry: pnpm typecheck


### PR DESCRIPTION
Normalizes pre-commit ordering so the repository-wide pnpm/Prettier formatter runs immediately after the generic safety/fixer hooks and before actionlint, markdownlint, codespell, typechecking, and tests.

No hook versions or behavior change. The pre-commit configuration and formatting check pass.