### PR TITLE
docs: update documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 <h3 align="center">
   <a href="https://paradedb.com">Website</a> &bull;
-  <a href="https://docs.paradedb.com">Docs</a> &bull;
+  <a href="https://paradedb.com/docs">Docs</a> &bull;
   <a href="https://paradedb.com/slack/">Community</a> &bull;
   <a href="https://paradedb.com/blog/">Blog</a> &bull;
-  <a href="https://docs.paradedb.com/changelog/">Changelog</a>
+  <a href="https://paradedb.com/docs/changelog/">Changelog</a>
 </h3>
 
 <p align="center">
@@ -36,7 +36,7 @@
 
 ## ParadeDB for Drizzle
 
-The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both [full-text search](https://docs.paradedb.com/documentation/full-text/overview) and [vector search](https://docs.paradedb.com/documentation/vector/overview) over pgvector `vector` types. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#drizzle) to begin.
+The official [Drizzle](https://orm.drizzle.team/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both [full-text search](https://paradedb.com/docs/documentation/full-text/overview) and [vector search](https://paradedb.com/docs/documentation/vector/overview) over pgvector `vector` types. Follow the [getting started guide](https://paradedb.com/docs/documentation/getting-started/environment#drizzle) to begin.
 
 ## Requirements & Compatibility
 


### PR DESCRIPTION
## Summary

- update ParadeDB documentation links from docs.paradedb.com to paradedb.com/docs
- preserve every existing documentation path and anchor

## Verification

- confirmed representative replacement URLs resolve successfully
- git diff --check
- verified no obsolete documentation URLs remain, excluding the intentional legacy-host redirect rules in the website repository